### PR TITLE
Dev

### DIFF
--- a/src/components/PostCard.astro
+++ b/src/components/PostCard.astro
@@ -1,6 +1,7 @@
 ---
 import { type CollectionEntry, render } from "astro:content";
 import path from "node:path";
+import type { ImageMetadata } from "astro";
 import { Icon } from "astro-icon/components";
 import I18nKey from "../i18n/i18nKey";
 import { i18n } from "../i18n/translation";
@@ -17,7 +18,7 @@ interface Props {
 	updated?: Date;
 	tags: string[];
 	category: string | null;
-	image: string;
+	image: string | ImageMetadata | undefined;
 	description: string;
 	draft: boolean;
 	style: string;

--- a/src/components/SocialShare.astro
+++ b/src/components/SocialShare.astro
@@ -272,7 +272,13 @@ const sharePlatforms = [
 
 		// Web Share API 支持
 		if ("share" in navigator) {
+			const existing = shareButtonsContainer.querySelector("[data-native-share]") as HTMLButtonElement | null;
+			if (existing) {
+				shareButtonsContainer.removeChild(existing);
+			}
+
 			const nativeShareBtn = document.createElement("button");
+			nativeShareBtn.dataset.nativeShare = "";
 			nativeShareBtn.className =
 				"share-btn group flex items-center gap-2 px-4 py-2 rounded-lg text-white bg-indigo-500 hover:bg-indigo-600 dark:bg-indigo-600 dark:hover:bg-indigo-700 transition-all duration-200 hover:-translate-y-0.5 hover:shadow-lg active:translate-y-0";
 			nativeShareBtn.innerHTML = `
@@ -304,6 +310,16 @@ const sharePlatforms = [
 		document.addEventListener("DOMContentLoaded", initShareButtons);
 	} else {
 		initShareButtons();
+	}
+
+	const setupSwupHooks = () => {
+		window.swup.hooks.on("page:view", initShareButtons);
+	};
+
+	if (window.swup) {
+		setupSwupHooks();
+	} else {
+		document.addEventListener("swup:enable", setupSwupHooks);
 	}
 </script>
 

--- a/src/components/misc/ImageWrapper.astro
+++ b/src/components/misc/ImageWrapper.astro
@@ -1,9 +1,10 @@
 ---
 import path from "node:path";
+import type { ImageMetadata } from "astro";
 
 interface Props {
 	id?: string;
-	src: string | string[];
+	src: string | string[] | ImageMetadata;
 	class?: string;
 	alt?: string;
 	position?: string;
@@ -32,16 +33,21 @@ const {
 	sizes,
 } = Astro.props;
 const className = Astro.props.class;
-const src = Array.isArray(Astro.props.src)
-	? Astro.props.src[0] || ""
-	: Astro.props.src;
+const rawSrc = Astro.props.src;
+const src = Array.isArray(rawSrc)
+	? rawSrc[0] || ""
+	: typeof rawSrc === "object" && rawSrc !== null && "src" in rawSrc
+		? rawSrc.src
+		: rawSrc;
 
-const isLocal = !(
-	src.startsWith("/") ||
-	src.startsWith("http") ||
-	src.startsWith("https") ||
-	src.startsWith("data:")
-);
+const isLocal =
+	src !== "" &&
+	!(
+		src.startsWith("/") ||
+		src.startsWith("http") ||
+		src.startsWith("https") ||
+		src.startsWith("data:")
+	);
 const isPublic = src.startsWith("/");
 
 // TODO temporary workaround for images dynamic import

--- a/src/components/misc/ImageWrapper.astro
+++ b/src/components/misc/ImageWrapper.astro
@@ -34,10 +34,15 @@ const {
 } = Astro.props;
 const className = Astro.props.class;
 const rawSrc = Astro.props.src;
-const src = Array.isArray(rawSrc)
-	? rawSrc[0] || ""
-	: typeof rawSrc === "object" && rawSrc !== null && "src" in rawSrc
-		? rawSrc.src
+const isImageMetadata =
+	typeof rawSrc === "object" &&
+	rawSrc !== null &&
+	!Array.isArray(rawSrc) &&
+	"format" in rawSrc;
+const src = isImageMetadata
+	? ""
+	: Array.isArray(rawSrc)
+		? rawSrc[0] || ""
 		: rawSrc;
 
 const isLocal =
@@ -50,11 +55,11 @@ const isLocal =
 	);
 const isPublic = src.startsWith("/");
 
-// TODO temporary workaround for images dynamic import
-// https://github.com/withastro/astro/issues/3373
 // biome-ignore lint/suspicious/noImplicitAnyLet: <check later>
 let img;
-if (isLocal) {
+if (isImageMetadata) {
+	img = rawSrc;
+} else if (isLocal) {
 	const files = import.meta.glob<ImageMetadata>("../../**", {
 		import: "default",
 	});
@@ -77,6 +82,6 @@ const imageStyle = `object-position: ${position}`;
 ---
 <div id={id} class:list={[className, 'overflow-hidden relative']}>
     <div class="transition absolute inset-0 dark:bg-black/10 bg-opacity-50 pointer-events-none"></div>
-    {isLocal && img && <Image src={img} alt={alt || ""} class={imageClass} style={imageStyle} loading={loading} decoding={decoding} fetchpriority={fetchpriority} widths={widths} sizes={sizes}/>}
-    {!isLocal && <img src={isPublic ? url(src) : src} alt={alt || ""} class={imageClass} style={imageStyle} loading={loading} decoding={decoding} fetchpriority={fetchpriority}/>}
+    {(isLocal || isImageMetadata) && img && <Image src={img} alt={alt || ""} class={imageClass} style={imageStyle} loading={loading} decoding={decoding} fetchpriority={fetchpriority} widths={widths} sizes={sizes}/>}
+    {!isLocal && !isImageMetadata && <img src={isPublic ? url(src) : src} alt={alt || ""} class={imageClass} style={imageStyle} loading={loading} decoding={decoding} fetchpriority={fetchpriority}/>}
 </div>

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -4,24 +4,25 @@ import { z } from "astro/zod";
 
 const postsCollection = defineCollection({
 	loader: glob({ pattern: "**/*.{md,mdx}", base: "./src/content/posts" }),
-	schema: z.object({
-		title: z.string(),
-		published: z.date(),
-		updated: z.date().optional(),
-		draft: z.boolean().optional().default(false),
-		description: z.string().optional().default(""),
-		image: z.string().optional().default(""),
-		tags: z.array(z.string()).optional().default([]),
-		category: z.string().optional().nullable().default(""),
-		lang: z.string().optional().default(""),
-		pinned: z.boolean().optional().default(false),
+	schema: ({ image }) =>
+		z.object({
+			title: z.string(),
+			published: z.date(),
+			updated: z.date().optional(),
+			draft: z.boolean().optional().default(false),
+			description: z.string().optional().default(""),
+			image: image().optional(),
+			tags: z.array(z.string()).optional().default([]),
+			category: z.string().optional().nullable().default(""),
+			lang: z.string().optional().default(""),
+			pinned: z.boolean().optional().default(false),
 
-		/* For internal use */
-		prevTitle: z.string().default(""),
-		prevSlug: z.string().default(""),
-		nextTitle: z.string().default(""),
-		nextSlug: z.string().default(""),
-	}),
+			/* For internal use */
+			prevTitle: z.string().default(""),
+			prevSlug: z.string().default(""),
+			nextTitle: z.string().default(""),
+			nextSlug: z.string().default(""),
+		}),
 });
 
 const specCollection = defineCollection({

--- a/src/content/posts/markdown-extended.md
+++ b/src/content/posts/markdown-extended.md
@@ -3,7 +3,6 @@ title: Markdown Extended Features
 published: 2024-05-01
 updated: 2026-05-31
 description: 'Read more about Markdown features in Fuwari'
-image: ''
 tags: [Demo, Example, Markdown, Fuwari]
 category: 'Examples'
 draft: true 

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -37,7 +37,13 @@ interface Props {
 	setOGTypeArticle?: boolean;
 }
 
-let { title, banner, description, lang, setOGTypeArticle } = Astro.props;
+let {
+	title,
+	banner: rawBanner,
+	description,
+	lang,
+	setOGTypeArticle,
+} = Astro.props;
 
 // apply a class to the body element to decide the height of the banner, only used for initial page load
 // Swup can update the body for each page visit, but it's after the page transition, causing a delay for banner height change
@@ -47,13 +53,13 @@ const isHomePage = pathsEqual(Astro.url.pathname, url("/"));
 // defines global css variables
 // why doing this in Layout instead of GlobalStyles: https://github.com/withastro/astro/issues/6728#issuecomment-1502203757
 const configHue = siteConfig.themeColor.hue;
-if (!banner || typeof banner !== "string" || banner.trim() === "") {
-	banner =
-		typeof siteConfig.banner.src === "string" ? siteConfig.banner.src : "";
-}
 
-// TODO don't use post cover as banner for now
-banner = typeof siteConfig.banner.src === "string" ? siteConfig.banner.src : "";
+const siteBanner =
+	typeof siteConfig.banner.src === "string" ? siteConfig.banner.src : "";
+const ogImage =
+	rawBanner && typeof rawBanner === "string" && rawBanner.trim() !== ""
+		? rawBanner
+		: siteBanner;
 
 const enableBanner = siteConfig.banner.enable;
 
@@ -104,10 +110,12 @@ const bannerOffset =
         <meta property="og:type" content="website" />
         )}
 
+		{ogImage && <meta property="og:image" content={new URL(ogImage, Astro.site).href}>}
 		<meta name="twitter:card" content="summary_large_image">
 		<meta property="twitter:url" content={Astro.url}>
 		<meta name="twitter:title" content={pageTitle}>
 		<meta name="twitter:description" content={description || pageTitle}>
+		{ogImage && <meta name="twitter:image" content={new URL(ogImage, Astro.site).href}>}
 
 		<meta name="viewport" content="width=device-width" />
 		<meta name="generator" content={Astro.generator} />

--- a/src/pages/posts/[...slug].astro
+++ b/src/pages/posts/[...slug].astro
@@ -38,6 +38,15 @@ export async function getStaticPaths() {
 const { entry } = Astro.props;
 const { Content, headings, remarkPluginFrontmatter } = await render(entry);
 
+const postImageSrc = entry.data.image
+	? typeof entry.data.image === "object"
+		? entry.data.image.src
+		: entry.data.image
+	: "";
+const shareImageUrl = postImageSrc
+	? new URL(postImageSrc, Astro.site).href
+	: "";
+
 const jsonLd = {
 	"@context": "https://schema.org",
 	"@type": "BlogPosting",
@@ -72,7 +81,7 @@ const giscusConfig = {
 	crossorigin: "anonymous",
 };
 ---
-<MainGridLayout banner={entry.data.image} title={entry.data.title} description={entry.data.description} lang={entry.data.lang} setOGTypeArticle={true} headings={headings}>
+<MainGridLayout banner={postImageSrc} title={entry.data.title} description={entry.data.description} lang={entry.data.lang} setOGTypeArticle={true} headings={headings}>
     <script is:inline slot="head" type="application/ld+json" set:html={JSON.stringify(jsonLd)}></script>
     <div class="flex w-full rounded-[var(--radius-large)] overflow-hidden relative mb-4">
         <div id="post-container" class:list={["card-base z-10 px-6 md:px-9 pt-6 pb-4 relative w-full ",
@@ -123,9 +132,9 @@ const giscusConfig = {
             </div>
 
             <!-- always show cover as long as it has one -->
-
             {entry.data.image &&
-                <ImageWrapper id="post-cover" src={entry.data.image} basePath={path.join("content/posts/", getPostRelativeDir(entry.id))} class="mb-8 rounded-xl banner-container onload-animation"/>
+
+                <ImageWrapper id="post-cover" src={postImageSrc} basePath={path.join("content/posts/", getPostRelativeDir(entry.id))} class="mb-8 rounded-xl banner-container onload-animation"/>
             }
 
 
@@ -145,7 +154,7 @@ const giscusConfig = {
 
   tags={entry.data.tags}
 
-  image={entry.data.image ? new URL(entry.data.image, Astro.site).href : ''}
+  image={shareImageUrl}
 
 ></SocialShare>
 


### PR DESCRIPTION
## Summary by Sourcery

改进整站博客文章图片处理和社交分享元数据。

新功能：
- 允许在文章 frontmatter 中将图片定义为 Astro 的 `ImageMetadata`，并支持使用本地图片资源的新示例文章。
- 基于每篇文章或站点级横幅图片添加 Open Graph 和 Twitter 图片 meta 标签。
- 启用原生 Web Share 按钮，并支持 Swup 页面切换，在导航后重新初始化分享控件。

错误修复：
- 修复 `ImageWrapper` 中本地图片检测不正确的问题，将空的图片源视为非本地资源。
- 确保在经过 Swup 驱动的页面切换后正确重新初始化 `SocialShare` 按钮，使已导航页面上的分享功能保持可用。

改进：
- 更新 `ImageWrapper` 和 `PostCard` 组件，使其既可接受字符串 URL，也可接受 `ImageMetadata` 对象，并安全地区分本地与远程图片路径。
- 优化布局横幅逻辑，可从文章横幅或全站横幅中派生 OG 图片，并避免在元数据中出现空值。
- 确保原生分享按钮不会被重复插入，在插入新实例前清理任何已存在的实例。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve blog post image handling and social sharing metadata across the site.

New Features:
- Allow post frontmatter images to be defined as Astro ImageMetadata and support a new example post using local image assets.
- Add Open Graph and Twitter image meta tags based on per-post or site-wide banner images.
- Enable native Web Share buttons with Swup page transition support to reinitialize sharing controls on navigation.

Bug Fixes:
- Fix incorrect local image detection in ImageWrapper by treating empty sources as non-local.
- Ensure SocialShare buttons are correctly reinitialized after Swup-powered page transitions to keep sharing functional on navigated pages.

Enhancements:
- Update ImageWrapper and PostCard components to accept both string URLs and ImageMetadata objects while safely detecting local vs remote image paths.
- Refine layout banner logic to derive an OG image from either the post banner or the global site banner and avoid empty values in metadata.
- Ensure SocialShare native share button is not duplicated by cleaning up any existing instance before inserting a new one.

</details>