### PR TITLE
feat: add GitHub contribution calendar to About page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,5 +34,3 @@ yarn.lock
 .reference/
 github-actions-key
 github-actions-key.pub
-
-AGENTS.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,103 @@
+# AGENTS.md
+
+## Quick reference
+
+- **Stack**: Astro 6.4 + Svelte 5 + Tailwind CSS 4 (Vite plugin, not PostCSS) + Stylus + MDX
+- **Package manager**: pnpm — enforced via `preinstall` hook + `.npmrc` `manage-package-manager-versions`
+- **Linter/formatter**: Biome 2.3 (not ESLint/Prettier)
+- **Site config**: `src/config.ts` (title, nav, profile, banner, announcement, expressive-code theme)
+- **Content collections**: `src/content/posts/` (blog posts), `src/content/spec/` (about, friends) — Astro Content Layer API with `glob` loader
+- **Deploy**: GitHub Pages (`.github/workflows/deploy.yml`, `withastro/action@v3`, Node 22)
+- **Migrated from Astro 5**: `MIGRATION-ASTRO-V6.md` documents the process
+
+## Commands
+
+| Purpose | Command |
+|---|---|
+| Dev server | `pnpm dev` (localhost:4321) |
+| Production build + Pagefind index | `pnpm build` (runs `astro build` then `pagefind --site dist`) |
+| Local preview of build | `pnpm preview` |
+| Type check | `pnpm type-check` (`tsc --noEmit --isolatedDeclarations`) — **currently fails, do not rely on** |
+| Astro diagnostics | `pnpm check` |
+| Lint + auto-fix | `pnpm lint` (`biome check --write ./src`) |
+| Format only | `pnpm format` (`biome format --write ./src`) |
+| New post | `pnpm new-post <filename>` (creates in `src/content/posts/` root) |
+
+## CI / workflows
+
+Three separate workflows run on push/PR to `main`:
+
+1. **Code quality** (`.github/workflows/biome.yml`): `biome ci ./src --reporter=github`
+2. **Build and Check** (`.github/workflows/build.yml`): `pnpm astro check` + `pnpm astro build` on Node **22 and 24**
+3. **Deploy** (`.github/workflows/deploy.yml`): `withastro/action@v3` with Node 22, pushes to GitHub Pages
+
+CI uses `pnpm install --frozen-lockfile`. Both build and deploy jobs configure SSH (`secrets.SSH_KEY`) for private dependencies.
+
+**Before committing**: run `pnpm lint` and `pnpm check`. Do **not** rely on `pnpm type-check` (see below).
+
+## Architecture
+
+- **Layouts**: `src/layouts/Layout.astro` (base), `MainGridLayout.astro` (grid with sidebar)
+- **Pages**: `src/pages/[...page].astro` (homepage/pagination), `src/pages/posts/[...slug].astro` (post routes)
+- **Components**: `src/components/` — Svelte 5 (`.svelte`) for interactive bits (search, light/dark toggle, archive), Astro (`.astro`) for static shells
+- **Plugins**: `src/plugins/` — custom remark/rehype for reading time, excerpts, admonitions, GitHub cards, directives, expressive-code extensions
+- **i18n**: `src/i18n/` — translation keys
+- **Styles**: `src/styles/` — Tailwind v4 (`tailwind.css`), Stylus (`.styl`), plain CSS
+- **Types**: `src/types/config.ts` defines all config interfaces
+
+## Path aliases
+
+`@components/*`, `@assets/*`, `@constants/*`, `@utils/*`, `@i18n/*`, `@layouts/*`, `@/*` → `src/*`
+
+## Code style
+
+- **Indentation**: tabs (Biome default)
+- **Quotes**: double quotes in JS/TS
+- **Svelte/Astro relaxation**: `useConst`, `useImportType`, `noUnusedVariables`, `noUnusedImports` off for `.svelte`/`.astro`/`.vue` (Biome overrides)
+- **CSS excluded**: Biome ignores `src/**/*.css`; Stylus unchecked by Biome
+
+## Content authoring
+
+Posts use Astro content collections (`src/content.config.ts`):
+- Required: `title` (string), `published` (date)
+- Optional: `updated`, `draft`, `description`, `image`, `tags`, `category`, `lang`, `pinned`
+- Internal: `prevTitle`, `prevSlug`, `nextTitle`, `nextSlug` — auto-populated, do not set
+
+Post folder convention: date-prefixed subdirs like `250826/PostTitle.md`. `pnpm new-post` creates in root only; nested dirs require manual creation.
+
+### MDX
+
+Use `.mdx` when you need `astro:assets` `<Image />` for optimized WebP images or JSX components. Store images in `{postname}.assets/` alongside the post file. Use plain `.md` with `![]()` for simple posts.
+
+## Build quirks
+
+- `pnpm build` → `astro build` then `pagefind --site dist` (indexes built HTML, not source)
+- Pagefind config (`pagefind.yml`) excludes KaTeX elements and `.search-panel` from indexing
+- Swup animation class is `transition-swup-` (not default `transition-`) — avoids Tailwind `transition-all` conflict
+- Expressive Code theme must be dark (`github-dark`) — only dark code backgrounds supported
+- Vite suppresses dynamic/static import duplicate warning in `astro.config.mjs`
+- **OverlayScrollbars CSS must be in frontmatter, NOT in `<script>`** — CSS imports in `<script>` are dynamically injected by Vite in dev mode. Swup's `updateHead: true` removes them during navigation, causing native scrollbar. Static CSS (frontmatter imports) is preserved.
+- **Never use `data-overlayscrollbars-initialize`** — it auto-initializes on the element, conflicting with manual `initCustomScrollbar()` on `<body>`.
+- **Always save/restore `html.style.overflow`** in Swup hooks — `page:view` must restore the saved value (not `''`) to avoid clearing OverlayScrollbars' own `overflow: hidden`.
+- **Banner height `--banner-height-extend` needs fallback + recalc** — this CSS variable is computed from `window.innerHeight * 0.30` in an `is:inline` `<head>` script. Edge session restore may load the page in a hidden tab where `innerHeight` is 0, breaking the home-page `translateY` layout. Must `var(..., 30vh)` CSS fallback + `visibilitychange`/`pageshow` listeners for recalculation (see inline script and CSS in `Layout.astro`).
+
+### Known warnings (non-fatal)
+
+- `astro check` / `astro build` emit: "`markdown.remarkPlugins`, `markdown.rehypePlugins`, and `markdown.remarkRehype` are deprecated." — Astro 6 migration artifact; safe to ignore for now.
+- Build produces 3 CSS optimization warnings (`Unexpected token Delim('&')`) from generated Tailwind classes — non-fatal, output is correct.
+
+### Type-check failures
+
+`pnpm type-check` currently fails with `--isolatedDeclarations` errors in:
+- `src/constants/constants.ts` (missing explicit types)
+- `src/content.config.ts` (inferred expression types)
+- `src/pages/rss.xml.ts` (missing return type)
+- `src/plugins/expressive-code/*.ts` (missing return types)
+- `src/utils/*.ts` (missing return types)
+
+These need explicit type annotations before the check can be used in CI. Do not block commits on this command.
+
+## Git / PR
+
+- Conventional Commits format per `CONTRIBUTING.md`
+- PRs should be single-purpose; run `pnpm lint` and `pnpm check` before submitting

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "astro": "6.4.2",
     "astro-expressive-code": "^0.42.0",
     "astro-icon": "^1.1.5",
+    "echarts": "^6.1.0",
     "hastscript": "^9.0.1",
     "katex": "^0.16.45",
     "markdown-it": "^14.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -74,6 +74,9 @@ importers:
       astro-icon:
         specifier: ^1.1.5
         version: 1.1.5
+      echarts:
+        specifier: ^6.1.0
+        version: 6.1.0
       hastscript:
         specifier: ^9.0.1
         version: 9.0.1
@@ -2400,6 +2403,9 @@ packages:
   eastasianwidth@0.2.0:
     resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
 
+  echarts@6.1.0:
+    resolution: {integrity: sha512-q0yaFPggC9FUdsWH4blavRWFmxdrIodbkoKNAjJudAI6CA9gNPxHtV2RcZNEepZVlk4yvBYkOkbk6HIVpIyHZA==}
+
   ejs@3.1.10:
     resolution: {integrity: sha512-UeJmFfOrAQS8OJWPZ4qtgHyWExa088/MtK5UEyoJGFH67cDEXkZSviOiKRCZ4Xij0zxI3JECgYs3oKx+AizQBA==}
     engines: {node: '>=0.10.0'}
@@ -4603,6 +4609,9 @@ packages:
   trough@2.2.0:
     resolution: {integrity: sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==}
 
+  tslib@2.3.0:
+    resolution: {integrity: sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg==}
+
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
@@ -5061,6 +5070,9 @@ packages:
 
   zod@4.4.3:
     resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
+
+  zrender@6.1.0:
+    resolution: {integrity: sha512-oEGMDB6pOP2S6OwRR4PdVv610zrjnA3Bh+JnSG12fYJlBKjtNAoEb5fSUoCOOINlH96I2fU38/A2UpRKs67xYQ==}
 
   zwitch@2.0.4:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
@@ -7615,6 +7627,11 @@ snapshots:
   duplexer@0.1.2: {}
 
   eastasianwidth@0.2.0: {}
+
+  echarts@6.1.0:
+    dependencies:
+      tslib: 2.3.0
+      zrender: 6.1.0
 
   ejs@3.1.10:
     dependencies:
@@ -10561,6 +10578,8 @@ snapshots:
 
   trough@2.2.0: {}
 
+  tslib@2.3.0: {}
+
   tslib@2.8.1: {}
 
   typed-array-buffer@1.0.3:
@@ -11001,5 +11020,9 @@ snapshots:
   zimmerframe@1.1.4: {}
 
   zod@4.4.3: {}
+
+  zrender@6.1.0:
+    dependencies:
+      tslib: 2.3.0
 
   zwitch@2.0.4: {}

--- a/src/components/CalendarHeatmap.svelte
+++ b/src/components/CalendarHeatmap.svelte
@@ -1,0 +1,107 @@
+<script lang="ts">
+import type { ECharts } from "echarts";
+import { onDestroy, onMount } from "svelte";
+
+export let commitData: Record<string, number>;
+
+interface TooltipParams {
+	value: [string, number];
+}
+
+let calendarEl: HTMLDivElement;
+let chart: ECharts | null = null;
+let resizeObserver: ResizeObserver | null = null;
+
+onMount(async () => {
+	if (!calendarEl || Object.keys(commitData).length === 0) return;
+
+	const echarts = await import("echarts");
+	chart = echarts.init(calendarEl);
+
+	const end = new Date();
+	const start = new Date();
+	start.setFullYear(start.getFullYear() - 1);
+
+	const seriesData = Object.entries(commitData).map(([date, count]) => [
+		date,
+		count,
+	]);
+
+	const option = {
+		tooltip: {
+			padding: 10,
+			backgroundColor: "#555",
+			borderColor: "#777",
+			borderWidth: 1,
+			formatter: (params: TooltipParams) => {
+				const [date, count] = params.value;
+				return `<div style="font-size: 14px;">${date}：${count} 次提交</div>`;
+			},
+		},
+		visualMap: {
+			show: false,
+			min: 0,
+			max: 5,
+			calculable: false,
+			inRange: {
+				symbol: "rect",
+				color: ["#ebedf0", "#c6e48b", "#7bc96f", "#239a3b", "#196127"],
+			},
+			itemWidth: 12,
+			itemHeight: 12,
+			orient: "horizontal",
+			left: "center",
+			top: 0,
+		},
+		calendar: [
+			{
+				top: 30,
+				left: "center",
+				range: [
+					`${start.getFullYear()}-${String(start.getMonth() + 1).padStart(2, "0")}-${String(start.getDate()).padStart(2, "0")}`,
+					`${end.getFullYear()}-${String(end.getMonth() + 1).padStart(2, "0")}-${String(end.getDate()).padStart(2, "0")}`,
+				],
+				cellSize: [13, 13],
+				splitLine: { show: false },
+				itemStyle: {
+					borderColor: "#fff",
+					borderWidth: 2,
+				},
+				yearLabel: { show: false },
+				monthLabel: {
+					nameMap: "cn",
+					fontSize: 11,
+					color: "#3C4858",
+				},
+				dayLabel: {
+					nameMap: "cn",
+					fontSize: 11,
+					color: "#3C4858",
+				},
+			},
+		],
+		series: [
+			{
+				type: "heatmap",
+				coordinateSystem: "calendar",
+				calendarIndex: 0,
+				data: seriesData,
+			},
+		],
+	};
+
+	chart.setOption(option);
+
+	resizeObserver = new ResizeObserver(() => {
+		chart?.resize();
+	});
+	resizeObserver.observe(calendarEl);
+});
+
+onDestroy(() => {
+	resizeObserver?.disconnect();
+	chart?.dispose();
+});
+</script>
+
+<div bind:this={calendarEl} class="w-full min-h-[185px]"></div>

--- a/src/components/CalendarHeatmap.svelte
+++ b/src/components/CalendarHeatmap.svelte
@@ -3,6 +3,8 @@ import type { ECharts } from "echarts";
 import { onDestroy, onMount } from "svelte";
 
 export let commitData: Record<string, number>;
+export let calendarStart: string;
+export let calendarEnd: string;
 
 interface TooltipParams {
 	value: [string, number];
@@ -21,10 +23,6 @@ onMount(async () => {
 
 	const isDark = document.documentElement.classList.contains("dark");
 	const textColor = isDark ? "#9ca3af" : "#3C4858";
-
-	const end = new Date();
-	const start = new Date();
-	start.setFullYear(start.getFullYear() - 1);
 
 	const seriesData = Object.entries(commitData).map(([date, count]) => [
 		date,
@@ -64,10 +62,7 @@ onMount(async () => {
 			{
 				top: 30,
 				left: "center",
-				range: [
-					`${start.getFullYear()}-${String(start.getMonth() + 1).padStart(2, "0")}-${String(start.getDate()).padStart(2, "0")}`,
-					`${end.getFullYear()}-${String(end.getMonth() + 1).padStart(2, "0")}-${String(end.getDate()).padStart(2, "0")}`,
-				],
+				range: [calendarStart, calendarEnd],
 				cellSize: [13, 13],
 				splitLine: { show: false },
 				itemStyle: {

--- a/src/components/CalendarHeatmap.svelte
+++ b/src/components/CalendarHeatmap.svelte
@@ -11,12 +11,16 @@ interface TooltipParams {
 let calendarEl: HTMLDivElement;
 let chart: ECharts | null = null;
 let resizeObserver: ResizeObserver | null = null;
+let themeObserver: MutationObserver | null = null;
 
 onMount(async () => {
 	if (!calendarEl || Object.keys(commitData).length === 0) return;
 
 	const echarts = await import("echarts");
-	chart = echarts.init(calendarEl);
+	chart = echarts.init(calendarEl, null, { renderer: "canvas" });
+
+	const isDark = document.documentElement.classList.contains("dark");
+	const textColor = isDark ? "#9ca3af" : "#3C4858";
 
 	const end = new Date();
 	const start = new Date();
@@ -30,9 +34,10 @@ onMount(async () => {
 	const option = {
 		tooltip: {
 			padding: 10,
-			backgroundColor: "#555",
-			borderColor: "#777",
+			backgroundColor: isDark ? "#374151" : "#555",
+			borderColor: isDark ? "#4b5563" : "#777",
 			borderWidth: 1,
+			textStyle: { color: isDark ? "#e5e7eb" : "#fff" },
 			formatter: (params: TooltipParams) => {
 				const [date, count] = params.value;
 				return `<div style="font-size: 14px;">${date}：${count} 次提交</div>`;
@@ -45,7 +50,9 @@ onMount(async () => {
 			calculable: false,
 			inRange: {
 				symbol: "rect",
-				color: ["#ebedf0", "#c6e48b", "#7bc96f", "#239a3b", "#196127"],
+				color: isDark
+					? ["#161b22", "#0e4429", "#006d32", "#26a641", "#39d353"]
+					: ["#ebedf0", "#c6e48b", "#7bc96f", "#239a3b", "#196127"],
 			},
 			itemWidth: 12,
 			itemHeight: 12,
@@ -64,19 +71,19 @@ onMount(async () => {
 				cellSize: [13, 13],
 				splitLine: { show: false },
 				itemStyle: {
-					borderColor: "#fff",
+					borderColor: isDark ? "#1a1a1a" : "#fff",
 					borderWidth: 2,
 				},
 				yearLabel: { show: false },
 				monthLabel: {
 					nameMap: "cn",
 					fontSize: 11,
-					color: "#3C4858",
+					color: textColor,
 				},
 				dayLabel: {
 					nameMap: "cn",
 					fontSize: 11,
-					color: "#3C4858",
+					color: textColor,
 				},
 			},
 		],
@@ -92,6 +99,32 @@ onMount(async () => {
 
 	chart.setOption(option);
 
+	// 监听主题变化
+	themeObserver = new MutationObserver(() => {
+		const newIsDark = document.documentElement.classList.contains("dark");
+		const newTextColor = newIsDark ? "#9ca3af" : "#3C4858";
+		chart?.setOption({
+			tooltip: {
+				backgroundColor: newIsDark ? "#374151" : "#555",
+				borderColor: newIsDark ? "#4b5563" : "#777",
+				textStyle: { color: newIsDark ? "#e5e7eb" : "#fff" },
+			},
+			visualMap: {
+				inRange: {
+					color: newIsDark
+						? ["#161b22", "#0e4429", "#006d32", "#26a641", "#39d353"]
+						: ["#ebedf0", "#c6e48b", "#7bc96f", "#239a3b", "#196127"],
+				},
+			},
+			calendar: [{
+				itemStyle: { borderColor: newIsDark ? "#1a1a1a" : "#fff" },
+				monthLabel: { color: newTextColor },
+				dayLabel: { color: newTextColor },
+			}],
+		});
+	});
+	themeObserver.observe(document.documentElement, { attributes: true, attributeFilter: ["class"] });
+
 	resizeObserver = new ResizeObserver(() => {
 		chart?.resize();
 	});
@@ -100,6 +133,7 @@ onMount(async () => {
 
 onDestroy(() => {
 	resizeObserver?.disconnect();
+	themeObserver?.disconnect();
 	chart?.dispose();
 });
 </script>

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -19,6 +19,14 @@ const GITHUB_TOKEN = import.meta.env.GITHUB_TOKEN;
 const REPO = "FFFold/fffold.github.io";
 
 let commitData: Record<string, number> = {};
+let calendarStatus: "ok" | "pending" | "error" = "ok";
+
+// 计算日历范围（构建时）
+const now = new Date();
+const calendarEnd = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, "0")}-${String(now.getDate()).padStart(2, "0")}`;
+const startDate = new Date(now);
+startDate.setFullYear(startDate.getFullYear() - 1);
+const calendarStart = `${startDate.getFullYear()}-${String(startDate.getMonth() + 1).padStart(2, "0")}-${String(startDate.getDate()).padStart(2, "0")}`;
 
 try {
 	const response = await fetch(
@@ -28,15 +36,15 @@ try {
 		},
 	);
 
-	if (response.status === 200) {
+	if (response.ok && response.status === 200) {
 		const weeklyData = await response.json();
 
 		if (Array.isArray(weeklyData)) {
 			weeklyData.forEach((week: { week: number; days: number[] }) => {
-				const startDate = new Date(week.week * 1000);
+				const weekStart = new Date(week.week * 1000);
 				week.days.forEach((count, i) => {
 					if (count > 0) {
-						const date = new Date(startDate);
+						const date = new Date(weekStart);
 						date.setDate(date.getDate() + i);
 						const key = `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, "0")}-${String(date.getDate()).padStart(2, "0")}`;
 						commitData[key] = count;
@@ -44,9 +52,16 @@ try {
 				});
 			});
 		}
+	} else if (response.status === 202) {
+		console.info("[about] GitHub commit stats are being generated (202 Accepted).");
+		calendarStatus = "pending";
+	} else {
+		console.error(`[about] Failed to load GitHub commit stats: ${response.status} ${response.statusText}`);
+		calendarStatus = "error";
 	}
 } catch (error) {
 	console.error("Failed to fetch GitHub commit data:", error);
+	calendarStatus = "error";
 }
 ---
 <MainGridLayout title={i18n(I18nKey.about)} description={i18n(I18nKey.about)}>
@@ -58,10 +73,14 @@ try {
 
             <h1 class="text-2xl font-bold mt-8 mb-4 text-neutral-900 dark:text-neutral-100">更新日历</h1>
             <div class="w-full overflow-x-auto overflow-y-hidden">
-                {Object.keys(commitData).length > 0 ? (
-                    <CalendarHeatmap commitData={commitData} client:load />
+                {calendarStatus === "ok" && Object.keys(commitData).length > 0 ? (
+                    <CalendarHeatmap commitData={commitData} calendarStart={calendarStart} calendarEnd={calendarEnd} client:load />
+                ) : calendarStatus === "pending" ? (
+                    <p class="text-neutral-600 dark:text-neutral-300 text-sm">GitHub 正在统计提交数据，请稍后再试...</p>
+                ) : calendarStatus === "error" ? (
+                    <p class="text-neutral-600 dark:text-neutral-300 text-sm">无法获取提交数据，请稍后再试</p>
                 ) : (
-                    <p class="text-neutral-600 dark:text-neutral-300 text-sm">暂无提交数据，GitHub API 正在计算中...</p>
+                    <p class="text-neutral-600 dark:text-neutral-300 text-sm">暂无提交记录</p>
                 )}
             </div>
         </div>

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -1,6 +1,7 @@
 ---
 
 import { getEntry, render } from "astro:content";
+import CalendarHeatmap from "@components/CalendarHeatmap.svelte";
 import Markdown from "@components/misc/Markdown.astro";
 import I18nKey from "../i18n/i18nKey";
 import { i18n } from "../i18n/translation";
@@ -13,6 +14,40 @@ if (!aboutPost) {
 }
 
 const { Content } = await render(aboutPost);
+
+const GITHUB_TOKEN = import.meta.env.GITHUB_TOKEN;
+const REPO = "FFFold/fffold.github.io";
+
+let commitData: Record<string, number> = {};
+
+try {
+	const response = await fetch(
+		`https://api.github.com/repos/${REPO}/stats/commit_activity`,
+		{
+			headers: GITHUB_TOKEN ? { Authorization: `token ${GITHUB_TOKEN}` } : {},
+		},
+	);
+
+	if (response.status === 200) {
+		const weeklyData = await response.json();
+
+		if (Array.isArray(weeklyData)) {
+			weeklyData.forEach((week: { week: number; days: number[] }) => {
+				const startDate = new Date(week.week * 1000);
+				week.days.forEach((count, i) => {
+					if (count > 0) {
+						const date = new Date(startDate);
+						date.setDate(date.getDate() + i);
+						const key = `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, "0")}-${String(date.getDate()).padStart(2, "0")}`;
+						commitData[key] = count;
+					}
+				});
+			});
+		}
+	}
+} catch (error) {
+	console.error("Failed to fetch GitHub commit data:", error);
+}
 ---
 <MainGridLayout title={i18n(I18nKey.about)} description={i18n(I18nKey.about)}>
     <div class="flex w-full rounded-[var(--radius-large)] overflow-hidden relative min-h-32">
@@ -20,6 +55,11 @@ const { Content } = await render(aboutPost);
             <Markdown class="mt-2">
                 <Content />
             </Markdown>
+
+            <h1 class="text-2xl font-bold mt-8 mb-4">更新日历</h1>
+            <div class="w-full overflow-x-auto overflow-y-hidden">
+                <CalendarHeatmap commitData={commitData} client:load />
+            </div>
         </div>
     </div>
 </MainGridLayout>

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -36,7 +36,7 @@ try {
 		},
 	);
 
-	if (response.ok && response.status === 200) {
+	if (response.status === 200) {
 		const weeklyData = await response.json();
 
 		if (Array.isArray(weeklyData)) {

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -56,9 +56,13 @@ try {
                 <Content />
             </Markdown>
 
-            <h1 class="text-2xl font-bold mt-8 mb-4">更新日历</h1>
+            <h1 class="text-2xl font-bold mt-8 mb-4 text-neutral-900 dark:text-neutral-100">更新日历</h1>
             <div class="w-full overflow-x-auto overflow-y-hidden">
-                <CalendarHeatmap commitData={commitData} client:load />
+                {Object.keys(commitData).length > 0 ? (
+                    <CalendarHeatmap commitData={commitData} client:load />
+                ) : (
+                    <p class="text-neutral-600 dark:text-neutral-300 text-sm">暂无提交数据，GitHub API 正在计算中...</p>
+                )}
             </div>
         </div>
     </div>


### PR DESCRIPTION
## Summary
- 新增 CalendarHeatmap.svelte 组件，使用 ECharts 渲染 GitHub 贡献日历热力图
- 修改 about.astro，在构建时通过 GitHub API 获取提交数据（SSG）
- 支持响应式布局、tooltip 显示、动态加载 ECharts

## 实现细节
- 数据来源：GitHub REST API /stats/commit_activity 端点
- 获取方式：构建时获取（SSG），支持 GITHUB_TOKEN 环境变量提高速率限制
- 可视化：ECharts 日历热力图，GitHub 风格绿色渐变

## Test Plan
- [ ] pnpm check 无错误
- [ ] pnpm build 构建成功
- [ ] About 页面显示日历热力图
- [ ] 有提交的日期显示绿色
- [ ] 鼠标悬停显示 tooltip

## 由 Sourcery 提供的摘要

在 About 页面添加一个 GitHub 贡献日历可视化组件，使用预先获取的提交活动数据。

新功能：
- 在 About 页面显示一个 GitHub 风格的仓库提交活动日历热力图。
- 引入可复用的 Svelte `CalendarHeatmap` 组件，使用 ECharts 渲染贡献数据。

增强：
- 在构建时使用 GitHub REST API 获取仓库提交统计信息，并支持可选的基于 Token 的认证以进行速率限制。
- 在新的 `AGENTS.md` 指南中记录项目技术栈、工作流、架构以及开发约定。

构建：
- 添加 ECharts 作为新的前端依赖，用于渲染日历热力图。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a GitHub contribution calendar visualization to the About page using pre-fetched commit activity data.

New Features:
- Display a GitHub-style calendar heatmap of repository commit activity on the About page.
- Introduce a reusable Svelte CalendarHeatmap component powered by ECharts to render contribution data.

Enhancements:
- Fetch GitHub repo commit statistics at build time using the GitHub REST API with optional token-based authentication for rate limiting.
- Document project stack, workflows, architecture, and development conventions in a new AGENTS.md guide.

Build:
- Add ECharts as a new frontend dependency for rendering the calendar heatmap.

</details>