### PR TITLE
refactor: move calendar heatmap date range calculation to runtime

### DIFF
--- a/src/components/CalendarHeatmap.svelte
+++ b/src/components/CalendarHeatmap.svelte
@@ -3,8 +3,6 @@ import type { ECharts } from "echarts";
 import { onDestroy, onMount } from "svelte";
 
 export let commitData: Record<string, number>;
-export let calendarStart: string;
-export let calendarEnd: string;
 export let totalCommits: number;
 export let activeDays: number;
 export let currentStreak: number;
@@ -29,6 +27,16 @@ onMount(async () => {
 
 	isDark = document.documentElement.classList.contains("dark");
 	const textColor = isDark ? "#9ca3af" : "#3C4858";
+
+	const now = new Date();
+	const fmt = (d: Date) =>
+		`${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}`;
+	const liveCalendarEnd = fmt(now);
+	const liveCalendarStart = (() => {
+		const d = new Date(now);
+		d.setFullYear(d.getFullYear() - 1);
+		return fmt(d);
+	})();
 
 	const seriesData = Object.entries(commitData).map(([date, count]) => [
 		date,
@@ -72,7 +80,7 @@ onMount(async () => {
 			{
 				top: 30,
 				left: "center",
-				range: [calendarStart, calendarEnd],
+				range: [liveCalendarStart, liveCalendarEnd],
 				cellSize: [13, 13],
 				splitLine: { show: false },
 				itemStyle: {

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -16,13 +16,6 @@ if (!aboutPost) {
 
 const { Content } = await render(aboutPost);
 
-// 计算日历范围（构建时）
-const now = new Date();
-const calendarEnd = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, "0")}-${String(now.getDate()).padStart(2, "0")}`;
-const startDate = new Date(now);
-startDate.setFullYear(startDate.getFullYear() - 1);
-const calendarStart = `${startDate.getFullYear()}-${String(startDate.getMonth() + 1).padStart(2, "0")}-${String(startDate.getDate()).padStart(2, "0")}`;
-
 // 从 git log 获取提交数据
 let commitData: Record<string, number> = {};
 
@@ -86,8 +79,6 @@ if (commitDates.length > 0) {
     {Object.keys(commitData).length > 0 ? (
         <CalendarHeatmap 
             commitData={commitData} 
-            calendarStart={calendarStart} 
-            calendarEnd={calendarEnd} 
             totalCommits={totalCommits}
             activeDays={activeDays}
             currentStreak={currentStreak}


### PR DESCRIPTION
- Remove `calendarStart` and `calendarEnd` exported props from CalendarHeatmap component
- Calculate calendar date range dynamically in component's onMount lifecycle
- Remove build-time calendar date calculation from about page
- Simplify CalendarHeatmap component usage by eliminating date range props

## Summary by Sourcery

将日历热力图的日期范围计算从构建时移到运行时，并简化组件 API。

增强内容：
- 在 `CalendarHeatmap` 组件挂载时动态计算日历热力图的开始和结束日期，而不是通过 props 传入。
- 通过移除 `calendarStart` 和 `calendarEnd` 这两个 props，并将日期范围逻辑内置到组件中，简化 `CalendarHeatmap` 的使用方式。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Move calendar heatmap date range calculation from build time to runtime and simplify the component API.

Enhancements:
- Compute calendar heatmap start and end dates dynamically in the CalendarHeatmap component on mount instead of passing them as props.
- Simplify CalendarHeatmap usage by removing calendarStart and calendarEnd props and internalizing date range logic in the component.

</details>